### PR TITLE
feat: version printing for multiqc

### DIFF
--- a/mosdepth/0.3.6/Dockerfile
+++ b/mosdepth/0.3.6/Dockerfile
@@ -1,0 +1,61 @@
+# Define version args for both builds
+ARG mosdepth_version="0.3.6"
+ARG python_version="3.9"
+ARG snakemakewrapperutils_version="0.3.1"
+
+# The build-stage image:
+FROM continuumio/miniconda3:4.10.3 AS build
+
+# Import version-args to use when installing
+ARG mosdepth_version
+ARG python_version
+ARG snakemakewrapperutils_version
+#RUN echo "The args are $mosdepth_version $python_version $snakemakewrapperutils_version"
+
+# Install conda-pack:
+RUN conda install -c conda-forge conda-pack && \
+    conda create --name hydra -c bioconda  -c conda-forge \
+	  mosdepth=$mosdepth_version \
+	  python=$python_version \
+      snakemake-wrapper-utils=$snakemakewrapperutils_version
+
+# Use conda-pack to create a standalone enviornment
+# in /venv:
+RUN conda-pack -n hydra -o /tmp/env.tar
+WORKDIR /venv
+RUN tar xf /tmp/env.tar
+
+# We've put venv in same path it'll be in final image,
+# so now fix up paths:
+RUN /venv/bin/conda-unpack
+
+# # The runtime-stage image; we can use Debian as the
+# # base image since the Conda env also includes Python
+# # for us.
+FROM debian:buster-slim AS runtime
+
+# Import version args to covert to env which persists after build command
+ARG mosdepth_version
+ARG python_version
+ARG snakemakewrapperutils_version
+ENV mosdepth=$mosdepth_version
+ENV python=$python_version
+ENV snakemakewrapperutils=$snakemakewrapperutils_version
+#RUN echo "The envs are: ${mosdepth} ${python} ${snakemakewrapperutils}"
+
+################## METADATA ######################
+LABEL maintainer="arielle.munters@scilifelab.uu.se"
+LABEL version=${mosdepth}
+LABEL mosdepth=${mosdepth}
+LABEL snakemake-wrapper-utils=${snakemakewrapperutils}
+LABEL python=${python}
+
+# Copy /venv from the previous stage:
+# to /usr/local to make it possible
+# running the softwares without activating
+# any conda env
+COPY --from=build /venv /usr
+
+COPY print_version.sh /print_version.sh
+RUN chmod +x /print_version.sh
+ENTRYPOINT /print_version.sh "mosdepth-container" "mosdepth" $mosdepth "python" $python "snakemake-wrapper-utils" $snakemakewrapperutils

--- a/mosdepth/Dockerfile
+++ b/mosdepth/Dockerfile
@@ -33,4 +33,4 @@ LABEL snakemake-wrapper-utils=0.3.1
 # to /usr/local to make it possible
 # running the softwares without activating
 # any conda env
-COPY --from=build /venv /usr/local
+COPY --from=build /venv /usr

--- a/print_version.sh
+++ b/print_version.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Script to create yaml with $program: $version for MultiQC > v1.16
+# First input = base for file, remaining input program version pairs
+
+filebase=$1
+echo -n "" > ${filebase}_mqc_versions.yaml &&
+while [ ! -z "$2" ]  # while $2 is not empty
+do
+  echo -e $2': "'$3'"' >> ${filebase}_mqc_versions.yaml
+  shift 2
+done &&
+/bin/bash


### PR DESCRIPTION
Hopefully will print a yaml file (`${containername}-container_mqc_versions.yaml` ) each time the container is run that can be use as input in MultiQC >v1.16 to be added to the version table at the end of the report.

1. Not sure the location of print_version.sh files work with how Docker builds the containers..
2. Singularity seem a bit vague how it mounts the pwd so i hope the yaml file ends up in the working dir :sweat_smile: 