### PR TITLE
feat: update common to hydra-genetics v1.11.1

### DIFF
--- a/common/v1.11.1/Dockerfile
+++ b/common/v1.11.1/Dockerfile
@@ -1,18 +1,20 @@
 # The build-stage image:
-FROM continuumio/miniconda3:4.10.3 AS build
+FROM continuumio/miniconda3:23.5.2-0 AS build
 
 # Install conda-pack:
-RUN conda install -c conda-forge conda-pack && \
+RUN conda install -c conda-forge conda-pack conda-libmamba-solver && \
+	conda config --set solver libmamba && \
     conda create --name hydra -c bioconda  -c conda-forge \
 	  bcftools=1.15.1 \
 	  bedtools=2.30 \
 	  cyvcf2=0.30.15 \
 	  datrie=0.8.2 \
+	  git=2.39.1 \
 	  pysam=0.18.0 \
 	  python=3.9 \
 	  samtools=1.15 \
 	  pyvcf=0.6.8 \
-    snakemake-wrapper-utils=0.5.2 \
+	  snakemake-wrapper-utils=0.5.2 \
 	  tabix=1.11 \
 	  xlsxwriter=3.0.3
 
@@ -38,7 +40,8 @@ LABEL version=1.11.1
 LABEL bcftools=1.15.1
 LABEL bedtools=2.30
 LABEL datrie=0.8.2
-LABEL hydra-genetics=1.10.2
+LABEL git=2.39.1
+LABEL hydra-genetics=1.11.1
 LABEL python=3.9
 LABEL pysam=0.18.0
 LABEL samtools=1.15

--- a/common/v1.11.1/Dockerfile
+++ b/common/v1.11.1/Dockerfile
@@ -1,0 +1,55 @@
+# The build-stage image:
+FROM continuumio/miniconda3:4.10.3 AS build
+
+# Install conda-pack:
+RUN conda install -c conda-forge conda-pack && \
+    conda create --name hydra -c bioconda  -c conda-forge \
+	  bcftools=1.15.1 \
+	  bedtools=2.30 \
+	  cyvcf2=0.30.15 \
+	  datrie=0.8.2 \
+	  pysam=0.18.0 \
+	  python=3.9 \
+	  samtools=1.15 \
+	  pyvcf=0.6.8 \
+    snakemake-wrapper-utils=0.5.2 \
+	  tabix=1.11 \
+	  xlsxwriter=3.0.3
+
+
+# Use conda-pack to create a standalone enviornment
+# in /venv:
+RUN conda-pack -n hydra -o /tmp/env.tar
+WORKDIR /venv
+RUN tar xf /tmp/env.tar
+
+# We've put venv in same path it'll be in final image,
+# so now fix up paths:
+RUN /venv/bin/conda-unpack
+
+# The runtime-stage image; we can use Debian as the
+# base image since the Conda env also includes Python
+# for us.
+FROM debian:buster-slim AS runtime
+
+################## METADATA ######################
+LABEL maintainer="patrik.smeds@scilifelab.uu.se"
+LABEL version=1.11.1
+LABEL bcftools=1.15.1
+LABEL bedtools=2.30
+LABEL datrie=0.8.2
+LABEL hydra-genetics=1.10.2
+LABEL python=3.9
+LABEL pysam=0.18.0
+LABEL samtools=1.15
+LABEL pyvcf=0.6.8
+LABEL snakemake-wrapper-utils=0.5.2
+LABEL tabix=1.11
+LABEL xlsxwriter=3.0.3
+
+# Copy /venv from the previous stage:
+# to /usr/local to make it possible
+# running the softwares without activating
+# any conda env
+COPY --from=build /venv /usr
+RUN pip install --no-cache-dir hydra-genetics==1.11.1

--- a/common/v1.11.1/Dockerfile
+++ b/common/v1.11.1/Dockerfile
@@ -18,17 +18,6 @@ RUN conda install -c conda-forge conda-pack conda-libmamba-solver && \
 	  tabix=1.11 \
 	  xlsxwriter=3.0.3
 
-
-# Use conda-pack to create a standalone enviornment
-# in /venv:
-RUN conda-pack -n hydra -o /tmp/env.tar
-WORKDIR /venv
-RUN tar xf /tmp/env.tar
-
-# We've put venv in same path it'll be in final image,
-# so now fix up paths:
-RUN /venv/bin/conda-unpack
-
 # The runtime-stage image; we can use Debian as the
 # base image since the Conda env also includes Python
 # for us.
@@ -50,9 +39,5 @@ LABEL snakemake-wrapper-utils=0.5.2
 LABEL tabix=1.11
 LABEL xlsxwriter=3.0.3
 
-# Copy /venv from the previous stage:
-# to /usr/local to make it possible
-# running the softwares without activating
-# any conda env
-COPY --from=build /venv /usr
-RUN pip install --no-cache-dir hydra-genetics==1.11.1
+COPY --from=build /opt/conda /opt/conda
+ENV PATH=${PATH}:/opt/conda/envs/hydra/bin


### PR DESCRIPTION
* Added git to dockerfile to enable usage of hydra-gentics command line tool 
* Changed how the conda environment is copied to the final image. In the previous approach the bcftools plugins were not available when using bcftools