### PR TITLE
fix(fastp): fix python version to 3.11

### DIFF
--- a/fastp/v0.24.3/Dockerfile
+++ b/fastp/v0.24.3/Dockerfile
@@ -11,6 +11,7 @@ RUN conda install -c conda-forge conda-pack conda-libmamba-solver && \
     conda config --set solver libmamba && \
     conda create --name hydra -c bioconda  -c conda-forge \
         fastp=${VERSION} \
+        python=3.11 \
         snakemake-wrapper-utils=0.3.1
 
 # The runtime-stage image; we can use Debian as the


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to support Python 3.11 in the containerized environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->