### PR TITLE
fix(quarto): Add symbolic link for quarto editor in Dockerfile

### DIFF
--- a/quarto/v1.8.27/Dockerfile
+++ b/quarto/v1.8.27/Dockerfile
@@ -39,7 +39,8 @@ COPY --from=build /opt/conda/envs/hydra/ /opt/conda/envs/hydra/
 
 
 RUN mkdir -p /opt/conda/envs/hydra/bin/tools/x86_64/ && \
-    ln -s /opt/conda/envs/hydra/bin/deno /opt/conda/envs/hydra/bin/tools/x86_64/deno
+    ln -s /opt/conda/envs/hydra/bin/deno /opt/conda/envs/hydra/bin/tools/x86_64/deno && \
+    ln -s /opt/conda/envs/hydra/share/quarto/editor /opt/conda/envs/hydra/share/editor
 
 
 ENV PATH=${PATH}:/opt/conda/envs/hydra/bin


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded editor tooling availability in the runtime environment by optimizing tool accessibility and container configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->