### PR TITLE
fix: Add symbolic links for quarto share directories

### DIFF
--- a/quarto/v1.8.27/Dockerfile
+++ b/quarto/v1.8.27/Dockerfile
@@ -39,8 +39,12 @@ COPY --from=build /opt/conda/envs/hydra/ /opt/conda/envs/hydra/
 
 
 RUN mkdir -p /opt/conda/envs/hydra/bin/tools/x86_64/ && \
-    ln -s /opt/conda/envs/hydra/bin/deno /opt/conda/envs/hydra/bin/tools/x86_64/deno && \
-    ln -s /opt/conda/envs/hydra/share/quarto/editor /opt/conda/envs/hydra/share/editor
+    ln -s /opt/conda/envs/hydra/bin/deno /opt/conda/envs/hydra/bin/tools/x86_64/deno 
+
+RUN cd /opt/conda/envs/hydra/share/quarto && \
+    for dir in */; do \
+        ln -sf "/opt/conda/envs/hydra/share/quarto/$dir" "/opt/conda/envs/hydra/share/$dir"; \
+    done
 
 
 ENV PATH=${PATH}:/opt/conda/envs/hydra/bin

--- a/quarto/v1.8.27/Dockerfile
+++ b/quarto/v1.8.27/Dockerfile
@@ -39,11 +39,10 @@ COPY --from=build /opt/conda/envs/hydra/ /opt/conda/envs/hydra/
 
 
 RUN mkdir -p /opt/conda/envs/hydra/bin/tools/x86_64/ && \
-    ln -s /opt/conda/envs/hydra/bin/deno /opt/conda/envs/hydra/bin/tools/x86_64/deno 
-
-RUN cd /opt/conda/envs/hydra/share/quarto && \
-    for dir in */; do \
-        ln -sf "/opt/conda/envs/hydra/share/quarto/$dir" "/opt/conda/envs/hydra/share/$dir"; \
+    ln -s /opt/conda/envs/hydra/bin/deno /opt/conda/envs/hydra/bin/tools/x86_64/deno && \
+    for dir in /opt/conda/envs/hydra/share/quarto/*/; do \
+        dirname=$(basename "$dir"); \
+        ln -sf "$dir" "/opt/conda/envs/hydra/share/$dirname"; \
     done
 
 


### PR DESCRIPTION
Create symbolic links for all directories in the quarto share.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker image build configuration by restructuring symlink management for improved directory path accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->