### PR TITLE
feat: add pbmarkdup 1.2.0 with python3.11

### DIFF
--- a/pbmarkdup/1.2.0/Dockerfile
+++ b/pbmarkdup/1.2.0/Dockerfile
@@ -1,0 +1,32 @@
+ARG VERSION=1.2.0
+
+# The build-stage image:
+FROM continuumio/miniconda3:23.5.2-0 AS build
+
+ARG VERSION
+ENV VERSION=${VERSION}
+
+# Install conda-pack:
+RUN conda install -c conda-forge conda-pack conda-libmamba-solver && \
+    conda config --set solver libmamba && \
+    conda create --name hydra -c bioconda  -c conda-forge \
+        python=3.11 \
+        pbmarkdup=${VERSION}
+
+# The runtime-stage image; we can use Debian as the
+# base image since the Conda env also includes Python
+# for us.
+FROM debian:buster-slim AS runtime
+
+ARG VERSION
+ENV VERSION=${VERSION}
+
+################## METADATA ######################
+LABEL maintainer="padraic.corcoran@scilifelab.uu.se"
+LABEL version=${VERSION}
+LABEL pbmarkdup=${VERSION}
+LABEL python=3.11
+
+
+COPY --from=build /opt/conda/envs/hydra/ /opt/conda/envs/hydra/
+ENV PATH=${PATH}:/opt/conda/envs/hydra/bin


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Docker image build configuration for containerized deployment of pbmarkdup v1.2.0 with Python 3.11 runtime environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hydra-genetics/docker/pull/362?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->