### PR TITLE
feat: update to cnvkit latest version 0.9.13

### DIFF
--- a/cnvkit/v0.9.13/Dockerfile
+++ b/cnvkit/v0.9.13/Dockerfile
@@ -1,0 +1,33 @@
+ARG VERSION=0.9.13
+
+# The build-stage image:
+FROM continuumio/miniconda3:23.5.2-0 AS build
+
+ARG VERSION
+ENV VERSION=${VERSION}
+
+# Install conda-pack:
+RUN conda install -c conda-forge conda-pack conda-libmamba-solver && \
+    conda config --set solver libmamba && \
+    conda create --name hydra -c bioconda -c conda-forge \
+    cnvkit=${VERSION} \
+    snakemake-wrapper-utils=0.8.0
+
+# The runtime-stage image; we can use Debian as the
+# base image since the Conda env also includes Python
+# for us.
+FROM debian:buster-slim AS runtime
+
+ARG VERSION
+ENV VERSION=${VERSION}
+
+################## METADATA ######################
+LABEL maintainer="andrei.guliaev@scilifelab.uu.se"
+LABEL version=${VERSION}
+LABEL cnvkit=${VERSION}
+LABEL snakemake-wrapper-utils=0.8.0
+ 
+   
+COPY --from=build /opt/conda/envs/hydra/ /opt/conda/envs/hydra/
+ENV PATH=${PATH}:/opt/conda/envs/hydra/bin
+    


### PR DESCRIPTION
Check dependencies:
- CNVkit: https://github.com/etal/cnvkit/releases/tag/v0.9.13
    - [x] Python >= 3.10: requirement met in https://hub.docker.com/layers/continuumio/miniconda3/23.5.2-0/images/sha256-6e740ab48b873d9c04f3a1c56747026bfd43902cfa0f8e11c1c9cfe4f0a853ee (Python 3.11 used)

- Snakemake wrapper: https://snakemake-wrappers.readthedocs.io/en/stable/wrappers/bio/cnvkit/batch.html
    - [x] `snakemake-wrapper-utils=0.8.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new container image for `cnvkit` v0.9.13.
  * The image now includes a preconfigured runtime environment with the required command-line tools available out of the box.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->