### PR TITLE
feat: version-tagged images for ONT dorado

### DIFF
--- a/dorado/v1.1.1/Dockerfile
+++ b/dorado/v1.1.1/Dockerfile
@@ -1,5 +1,5 @@
 # The build-stage image:
-FROM ontresearch/dorado:shae423e761540b9d08b526a1eb32faf498f32e8f22 AS build
+FROM ontresearch/dorado@sha256:1a98a3d8a5341d98bd84dd41ce2bc2a5a2dae5cb31268d0b3aff9dfec52defd6 AS build
 
 ################## METADATA ######################
 LABEL maintainer="camille.clouard@scilifelab.uu.se"

--- a/dorado/v1.1.1/Dockerfile
+++ b/dorado/v1.1.1/Dockerfile
@@ -1,0 +1,7 @@
+# The build-stage image:
+FROM ontresearch/dorado:shae423e761540b9d08b526a1eb32faf498f32e8f22 AS build
+
+################## METADATA ######################
+LABEL maintainer="camille.clouard@scilifelab.uu.se"
+LABEL version=1.1.1
+LABEL dorado=1.1.1

--- a/dorado/v1.4.0/Dockerfile
+++ b/dorado/v1.4.0/Dockerfile
@@ -1,0 +1,7 @@
+# The build-stage image:
+FROM ontresearch/dorado:shac8f356489fa8b44b31beba841b84d2879de2088e AS build
+
+################## METADATA ######################
+LABEL maintainer="camille.clouard@scilifelab.uu.se"
+LABEL version=1.4.0
+LABEL dorado=1.4.0

--- a/dorado/v1.4.0/Dockerfile
+++ b/dorado/v1.4.0/Dockerfile
@@ -1,5 +1,5 @@
 # The build-stage image:
-FROM ontresearch/dorado:shac8f356489fa8b44b31beba841b84d2879de2088e AS build
+FROM ontresearch/dorado@sha256:6d875196de11126aa952da0075dae8fa2aabef13a6f6c4f93c2ac416de9d94a8 AS build
 
 ################## METADATA ######################
 LABEL maintainer="camille.clouard@scilifelab.uu.se"

--- a/dorado/v2.0.0/Dockerfile
+++ b/dorado/v2.0.0/Dockerfile
@@ -1,5 +1,5 @@
 # The build-stage image:
-FROM ontresearch/dorado:sha38b4ce849afa13eac8075f0b41cecd30799f169b AS build
+FROM ontresearch/dorado@sha256:8c0cdf8d4dfb3ffbbc34782affdcb215c0d1dfaa1372f1672b264064dd0d8e5a AS build
 
 ################## METADATA ######################
 LABEL maintainer="camille.clouard@scilifelab.uu.se"

--- a/dorado/v2.0.0/Dockerfile
+++ b/dorado/v2.0.0/Dockerfile
@@ -1,0 +1,7 @@
+# The build-stage image:
+FROM ontresearch/dorado:sha38b4ce849afa13eac8075f0b41cecd30799f169b AS build
+
+################## METADATA ######################
+LABEL maintainer="camille.clouard@scilifelab.uu.se"
+LABEL version=2.0.0
+LABEL dorado=2.0.0


### PR DESCRIPTION
Currently, the official images that are available at https://hub.docker.com/r/ontresearch/dorado do not show clear versioning in their name, which makes version tracking unstraightforward with hydra-genetics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added container build definitions for Dorado versions 1.1.1, 1.4.0, and 2.0.0.
  * Added version metadata to each Docker image for clearer identification and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->